### PR TITLE
corrected example parameter for external database in values.yaml

### DIFF
--- a/charts/awx/values.yaml
+++ b/charts/awx/values.yaml
@@ -101,7 +101,7 @@ awx:
     builtIn:
       enabled: true
     sslMode: prefer
-#    username:
+#    user:
 #    name:
 #    password:
 #    host:


### PR DESCRIPTION
templates/awx/secrets/secrets.yaml use  .Values.awx.database.user, not username